### PR TITLE
Support Fn::ImportValue

### DIFF
--- a/lib/kumogata2/plugin/ruby/string_ext.rb
+++ b/lib/kumogata2/plugin/ruby/string_ext.rb
@@ -90,6 +90,19 @@ module Kumogata2::Plugin::Ruby::StringExt
         #{null.inspect}
       end
 
+      def Fn__ImportValue(value)
+        value = {'Fn::ImportValue' => value}
+
+        case @__functions__
+        when Array
+          @__functions__ << value
+        when Hash
+          @__functions__.update(value)
+        end
+
+        #{null.inspect}
+      end
+
       def Ref(value)
         value = {'Ref' => value}
 


### PR DESCRIPTION
Support [Fn::ImportValue].

[Fn::ImportValue]: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-importvalue.html

Templates will be converted as follows by `String#fn_join()`:

```ruby
UserData do
  Fn__Base64 (<<-EOS).fn_join
    #!/bin/bash
    echo <%= Fn__ImportValue "bar" %>
  EOS
end
```

```json
"UserData": {
  "Fn::Base64": {
    "Fn::Join": [
      "",
      [
        "#!/bin/bash\n",
        "echo ",
        {
          "Fn::ImportValue": "bar"
        },
        "\n"
      ]
    ]
  }
}
```
