### PR TITLE
Deleted old option and extend expression support '-' and '.'

### DIFF
--- a/lib/kumogata2/plugin/ruby.rb
+++ b/lib/kumogata2/plugin/ruby.rb
@@ -34,7 +34,11 @@ class Kumogata2::Plugin::Ruby
 
   def devaluate_template(template)
     exclude_key = proc do |k|
-      k = k.to_s.gsub('::', '__')
+      k = k.to_s
+      k.gsub!('____', '-')
+      k.gsub!('___', '.')
+      k.gsub!('__', '::')
+      k.gsub!('_', ':')
       k !~ /\A[_a-z]\w+\Z/i and k !~ %r|\A/\S*\Z|
     end
 
@@ -50,7 +54,10 @@ class Kumogata2::Plugin::Ruby
           end
         end
       else
+        k.gsub('-', '____')
+        k.gsub('.', '___')
         k.gsub('::', '__')
+        k.gsub(':', '_')
       end
     end
 

--- a/lib/kumogata2/plugin/ruby/context.rb
+++ b/lib/kumogata2/plugin/ruby/context.rb
@@ -6,13 +6,13 @@ class Kumogata2::Plugin::Ruby::Context
   end
 
   def template(&block)
-    key_converter = proc do |key|
-      key = key.to_s
-      unless @options.skip_replace_underscore?
-        key.gsub!('__', '::')
-        key.gsub!('_', ':')
-      end
-      key
+    key_converter = proc do |k|
+      k = k.to_s
+      k.gsub!('____', '-')
+      k.gsub!('___', '.')
+      k.gsub!('__', '::')
+      k.gsub!('_', ':')
+      k
     end
 
     value_converter = proc do |v|


### PR DESCRIPTION
Add support expression '-' and '.'

- for example
    ```
  Foo do
    Type ...
    A____B___C__D abcd   => A-B.C::D
  end
    ```