### PR TITLE
Fix error at convert JSON to Ruby

### DIFF
--- a/lib/kumogata2/plugin/ruby.rb
+++ b/lib/kumogata2/plugin/ruby.rb
@@ -34,7 +34,7 @@ class Kumogata2::Plugin::Ruby
 
   def devaluate_template(template)
     exclude_key = proc do |k|
-      k = k.to_s
+      k = k.to_s.dup
       k.gsub!('____', '-')
       k.gsub!('___', '.')
       k.gsub!('__', '::')

--- a/spec/kumogata2-plugin-ruby_spec.rb
+++ b/spec/kumogata2-plugin-ruby_spec.rb
@@ -2,4 +2,19 @@ describe Kumogata2::Plugin::Ruby do
   it do
     expect(1).to eq 1
   end
+
+  describe "#dump" do
+    it "JSON format" do
+
+      data = <<-"JSON"
+      {
+        "Version": "2012-10-17"
+      }
+      JSON
+
+      opts = {}
+      template = Kumogata2::Plugin::Ruby.new(opts).dump(JSON.parse(data))
+      expect(template).to eq "template do\n  Version \"2012-10-17\"\nend\n"
+    end
+  end
 end


### PR DESCRIPTION
I found error at convert json format to ruby format.

```shell
$ rbenv exec bundle exec kumogata2 convert policy_sample.json --output-format rb
[ERROR] can't modify frozen String
```

It fiexd.

## Detail

keys in Hash is frozen, but replace(.gsub!) at convert process
So, copy keys to string data before gsub!

And, added test it case. 
Please setup travis-ci.

### Test results

before

```
Kumogata2::Plugin::Ruby
  should eq 1
  #dump
    JSON format (FAILED - 1)

Failures:

  1) Kumogata2::Plugin::Ruby#dump JSON format
     Failure/Error: k.gsub!('____', '-')

     RuntimeError:
       can't modify frozen String
     # ./lib/kumogata2/plugin/ruby.rb:38:in `gsub!'
     # ./lib/kumogata2/plugin/ruby.rb:38:in `block in devaluate_template'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:344:in `block in exclude_keys?'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:344:in `any?'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:344:in `exclude_keys?'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:196:in `deval0'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:185:in `deval'
     # ./vendor/bundle/gems/dslh-0.4.8/lib/dslh.rb:71:in `deval'
     # ./lib/kumogata2/plugin/ruby.rb:87:in `devaluate_template'
     # ./lib/kumogata2/plugin/ruby.rb:24:in `dump'
     # ./spec/kumogata2-plugin-ruby_spec.rb:16:in `block (3 levels) in <top (required)>'

Finished in 0.00179 seconds (files took 0.24081 seconds to load)
2 examples, 1 failure
```

after

```
Kumogata2::Plugin::Ruby
  should eq 1
  #dump
    JSON format

Finished in 0.00153 seconds (files took 0.22457 seconds to load)
2 examples, 0 failures
```